### PR TITLE
Output tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ the following command:
 
     sudo apt-get install libmagickwand-dev
 
+On Fedora and friends:
+
+    sudo dnf install ImageMagick-devel
+
 To build blockhash cd to the source directory and type:
 
     ./waf configure

--- a/blockhash.c
+++ b/blockhash.c
@@ -322,7 +322,7 @@ int process_image(char * fn, int bits, int quick, int debug)
     }
 
     char* hex = bits_to_hexhash(hash, bits*bits);
-    printf("%s %s\n", fn, hex);
+    printf("%s  %s\n", hex, fn);
 
     free(hex);
     free(hash);


### PR DESCRIPTION
Print hash before filename, separated by two spaces, consistent with the output of `md5sum` and commonsmachinery/blockhash-python#3.
